### PR TITLE
Add max-width container to limit page width

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,7 @@
     }
 
     .container {
-      max-width: 1000px;
+      max-width: 900px;
       margin: 0 auto;
     }
 
@@ -32,6 +32,10 @@
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
+    }
+
+    .container {
+      text-align: center;
     }
 
     .subtitle {
@@ -198,7 +202,7 @@
 <body>
   <div class="container">
   <h1>slowmo</h1>
-  <p class="subtitle">Universal slow-motion control for web animations</p>
+  <p class="subtitle">Slow down or speed up time, to debug or study web animations.</p>
 
   <div class="controls">
     <div class="speed-display" id="speed-display">1.0x</div>


### PR DESCRIPTION
Constrains the demo page to a standard max-width of 1000px and centers it. This prevents the content from stretching to the full browser width on large screens.