### PR TITLE
Enable cleanUrls for privacy-policy page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "pnpm run build:demo",
   "outputDirectory": "dist-demo",
-  "installCommand": "pnpm install"
+  "installCommand": "pnpm install",
+  "cleanUrls": true
 }


### PR DESCRIPTION
Adds `cleanUrls: true` to vercel.json so `/privacy-policy` works without the `.html` extension.