### PR TITLE
Fix npm auth and add missing CLI entry point

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           echo "Publishing version ${{ steps.versions.outputs.local }} to npm..."
           npm publish
           echo "Published successfully!"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         dial: resolve(__dirname, 'src/dial-api.ts'),
         react: resolve(__dirname, 'src/react.tsx'),
         recreate: resolve(__dirname, 'src/recreate.ts'),
+        'cli/index': resolve(__dirname, 'src/cli/index.ts'),
         'cli/recreate': resolve(__dirname, 'src/cli/recreate.ts'),
       },
       name: 'slowmo',


### PR DESCRIPTION
## Summary
- Fix auto-publish workflow npm authentication by explicitly writing auth token to `~/.npmrc`
- Add missing `cli/index` entry to vite build config so `dist/cli/index.js` is generated

Fixes the `ENEEDAUTH` error and `No bin file found at dist/cli/index.js` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)