### PR TITLE
Replace innerHTML with DOMParser for Trusted Types compatibility

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -7,6 +7,25 @@
 (function() {
   'use strict';
 
+  // ============================================
+  // TRUSTED TYPES-SAFE DOM HELPERS
+  // ============================================
+  // Some sites set CSP `require-trusted-types-for 'script'` which blocks
+  // innerHTML. We use DOMParser instead to avoid these errors entirely.
+
+  function safeSetHTML(el, html) {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    el.replaceChildren(...doc.body.childNodes);
+  }
+
+  function safeSetSVGContent(el, svgFragment) {
+    const doc = new DOMParser().parseFromString(
+      `<svg xmlns="http://www.w3.org/2000/svg">${svgFragment}</svg>`,
+      'image/svg+xml'
+    );
+    el.replaceChildren(...doc.documentElement.childNodes);
+  }
+
   // Avoid double injection (extension loaded twice)
   if (window.__slowmoExtensionLoaded) return;
   window.__slowmoExtensionLoaded = true;
@@ -458,7 +477,7 @@
       font-family: ui-monospace, 'SF Mono', Monaco, monospace;
     `;
 
-    root.innerHTML = `
+    safeSetHTML(root, `
       <svg viewBox="0 0 ${DIAL_SIZE} ${DIAL_SIZE}" style="width:100%;height:100%;filter:drop-shadow(0 4px 12px rgba(0,0,0,0.5));">
         <!-- Background circle -->
         <circle cx="${DIAL_RADIUS}" cy="${DIAL_RADIUS}" r="${DIAL_RADIUS}" fill="${COLOR_BG}"/>
@@ -488,7 +507,7 @@
         pointer-events: none;
         white-space: nowrap;
       ">${dialPaused ? 'paused' : formatDialSpeed(angleToSpeed(dialAngle)) + 'x'}</div>
-    `;
+    `);
 
     document.body.appendChild(root);
 
@@ -501,10 +520,10 @@
     }
 
     function updatePauseIcon() {
-      pauseIcon.innerHTML = dialPaused
+      safeSetSVGContent(pauseIcon, dialPaused
         ? `<path d="M-4.5 -8.5L7.5 0L-4.5 8.5Z" fill="${COLOR_BRASS}" stroke="${COLOR_BRASS}" stroke-width="1.5" stroke-linejoin="round"/>`
         : `<line x1="-4.5" y1="-8" x2="-4.5" y2="8" stroke="${COLOR_BRASS}" stroke-width="3" stroke-linecap="round"/>
-           <line x1="5.5" y1="-8" x2="5.5" y2="8" stroke="${COLOR_BRASS}" stroke-width="3" stroke-linecap="round"/>`;
+           <line x1="5.5" y1="-8" x2="5.5" y2="8" stroke="${COLOR_BRASS}" stroke-width="3" stroke-linecap="round"/>`);
     }
 
     function updateSpeedDisplay() {

--- a/src/dial.ts
+++ b/src/dial.ts
@@ -8,6 +8,25 @@
  */
 
 // ============================================
+// TRUSTED TYPES-SAFE DOM HELPERS
+// ============================================
+// Some sites set CSP `require-trusted-types-for 'script'` which blocks
+// innerHTML. We use DOMParser instead to avoid these errors entirely.
+
+function safeSetHTML(el: Element, html: string): void {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  el.replaceChildren(...Array.from(doc.body.childNodes));
+}
+
+function safeSetSVGContent(el: Element, svgFragment: string): void {
+  const doc = new DOMParser().parseFromString(
+    `<svg xmlns="http://www.w3.org/2000/svg">${svgFragment}</svg>`,
+    'image/svg+xml',
+  );
+  el.replaceChildren(...Array.from(doc.documentElement.childNodes));
+}
+
+// ============================================
 // CONSTANTS
 // ============================================
 
@@ -260,7 +279,7 @@ export function createDial(options: DialOptions): HTMLElement {
     </svg>
   `;
 
-  container.innerHTML = svg;
+  safeSetHTML(container, svg);
 
   // Speed display overlay
   const speedDisplay = document.createElement('div');
@@ -293,10 +312,10 @@ export function createDial(options: DialOptions): HTMLElement {
   function updatePauseIcon() {
     const iconGroup = container.querySelector('.dial-pause-icon') as SVGGElement;
     if (iconGroup) {
-      iconGroup.innerHTML = isPaused
+      safeSetSVGContent(iconGroup, isPaused
         ? `<path d="-4.5 -8.5L7.5 0L-4.5 8.5Z" fill="${COLOR_BRASS}" stroke="${COLOR_BRASS}" stroke-width="1.5" stroke-linejoin="round"/>`
         : `<line x1="-4.5" y1="-8" x2="-4.5" y2="8" stroke="${COLOR_BRASS}" stroke-width="3" stroke-linecap="round"/>
-           <line x1="5.5" y1="-8" x2="5.5" y2="8" stroke="${COLOR_BRASS}" stroke-width="3" stroke-linecap="round"/>`;
+           <line x1="5.5" y1="-8" x2="5.5" y2="8" stroke="${COLOR_BRASS}" stroke-width="3" stroke-linecap="round"/>`);
     }
   }
 

--- a/tests/unit/dial-api.test.ts
+++ b/tests/unit/dial-api.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
+// Mock DOMParser (needed since dial uses it instead of innerHTML for Trusted Types compat)
+const mockParsedElement = {
+  childNodes: [],
+};
+const mockParsedDoc = {
+  body: mockParsedElement,
+  documentElement: mockParsedElement,
+};
+vi.stubGlobal('DOMParser', class {
+  parseFromString() { return mockParsedDoc; }
+});
+
 // Mock DOM environment
 const mockBody = {
   appendChild: vi.fn(),
@@ -15,7 +27,7 @@ const mockElement = {
     cursor: '',
   },
   className: '',
-  innerHTML: '',
+  replaceChildren: vi.fn(),
   appendChild: vi.fn(),
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),


### PR DESCRIPTION
## Summary
- Sites with strict CSP (`require-trusted-types-for 'script'`) block all `innerHTML` assignments, causing a wall of console errors when the dial renders
- Replaced all 4 `innerHTML` calls in `extension/content.js` and `src/dial.ts` with `DOMParser`-based helpers (`safeSetHTML` and `safeSetSVGContent`)
- Updated test mocks to match the new approach

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `npm test` passes (pre-existing unrelated failure unchanged)
- [ ] Manually verify dial renders on a Trusted Types-enforcing site (e.g. YouTube)

🤖 Generated with [Claude Code](https://claude.com/claude-code)