### PR TITLE
Hide cursor during dial drag interactions

### DIFF
--- a/src/dial.ts
+++ b/src/dial.ts
@@ -476,14 +476,14 @@ export function createDial(options: DialOptions): HTMLElement {
       // Start timer to show move cursor hint if held
       holdDelayTimer = setTimeout(() => {
         if (mouseDownZone === 'center' && !hasDragged) {
-          container.style.cursor = 'move';
+          container.style.cursor = 'none';
         }
       }, HOLD_DELAY_MS);
     } else if (dist <= DIAL_RADIUS) {
       // Outer wheel zone - rotation
       mouseDownZone = 'wheel';
-      document.body.style.cursor = 'ew-resize';
-      container.style.cursor = 'ew-resize';
+      document.body.style.cursor = 'none';
+      container.style.cursor = 'none';
     }
   }
 
@@ -499,7 +499,7 @@ export function createDial(options: DialOptions): HTMLElement {
       if (distance > MIN_DRAG_DISTANCE) {
         hasDragged = true;
         clearHoldTimer();
-        document.body.style.cursor = 'move';
+        document.body.style.cursor = 'none';
 
         // Reposition dial: move by the same delta as the mouse
         // Mouse moved by (dx, dy), so dial should move by same amount


### PR DESCRIPTION
## Summary
- Hides the cursor when grabbing and dragging the dial, for both wheel rotation and center-zone repositioning
- The `ew-resize` cursor still appears on hover to indicate the draggable area
- Cursor restores to normal on mouse release

## Test plan
- [ ] Hover over the dial wheel — should show `ew-resize` cursor
- [ ] Grab and drag the wheel — cursor should disappear
- [ ] Release — cursor should reappear
- [ ] Hold center zone — cursor should hide after 150ms
- [ ] Drag to reposition — cursor should stay hidden until release

🤖 Generated with [Claude Code](https://claude.com/claude-code)